### PR TITLE
Do not start without password

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Use this application to deploy [Jupyter Notebook](https://jupyter.org/) to herok
 
 ## Quick start
 
-After deploying this application, jupyter is password protected with a random password. Set the environment variable `JUPYTER_NOTEBOOK_PASSWORD` and restart you app.
+Jupyter will not start, if the environment variable `JUPYTER_NOTEBOOK_PASSWORD`
+was not set.
 
 If you want to customize your app, easiest is to fork this repository.
 
@@ -18,7 +19,7 @@ If you forked this repository, you can link it to your heroku app afterwards.
 
 ### heroku - manual deployment
 
-Push this repository to your app or fork this repository on github and link your 
+Push this repository to your app or fork this repository on github and link your
 repository to your heroku app.
 
 Use the [heroku-buildpack-conda](https://github.com/p-a-c-o/heroku-buildpack-conda):

--- a/jupyterconfig.py
+++ b/jupyterconfig.py
@@ -1,15 +1,14 @@
-import os
-import traceback
-import IPython.lib
-
 try:
+    import os
+    import traceback
+    import IPython.lib
+    import pgcontents
+
     c = get_config()
 
     ### Password protection ###
-    c.NotebookApp.password = IPython.lib.passwd(
-        os.getenv('JUPYTER_NOTEBOOK_PASSWORD')
-
-    import pgcontents
+    passwd = os.getenv('JUPYTER_NOTEBOOK_PASSWORD')
+    c.NotebookApp.password = IPython.lib.passwd(passwd)
 
     ### PostresContentsManager ###
     database_url = os.getenv('DATABASE_URL', None)

--- a/jupyterconfig.py
+++ b/jupyterconfig.py
@@ -7,7 +7,7 @@ try:
 
     ### Password protection ###
     c.NotebookApp.password = IPython.lib.passwd(
-        os.getenv('JUPYTER_NOTEBOOK_PASSWORD'))
+        os.getenv('JUPYTER_NOTEBOOK_PASSWORD')
 
     import pgcontents
 

--- a/jupyterconfig.py
+++ b/jupyterconfig.py
@@ -1,31 +1,38 @@
 import os
-import uuid
+import traceback
 import IPython.lib
 
-c = get_config()
+try:
+    c = get_config()
 
-### Password protection ###
-c.NotebookApp.password = IPython.lib.passwd(
-    os.getenv('JUPYTER_NOTEBOOK_PASSWORD', default=str(uuid.uuid4())))
+    ### Password protection ###
+    c.NotebookApp.password = IPython.lib.passwd(
+        os.getenv('JUPYTER_NOTEBOOK_PASSWORD'))
 
-import pgcontents
+    import pgcontents
 
-### PostresContentsManager ###
-database_url = os.getenv('DATABASE_URL', None)
-if database_url:
-    # Tell IPython to use PostgresContentsManager for all storage.
-    c.NotebookApp.contents_manager_class = pgcontents.PostgresContentsManager
-    
-    # Set the url for the database used to store files.  See
-    # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#postgresql
-    # for more info on db url formatting.
-    c.PostgresContentsManager.db_url = database_url
-    
-    # PGContents associates each running notebook server with a user, allowing
-    # multiple users to connect to the same database without trampling each other's
-    # notebooks. By default, we use the result of result of getpass.getuser(), but
-    # a username can be specified manually like so:
-    c.PostgresContentsManager.user_id = 'heroku'
-    
-    # Set a maximum file size, if desired.
-    #c.PostgresContentsManager.max_file_size_bytes = 1000000 # 1MB File cap
+    ### PostresContentsManager ###
+    database_url = os.getenv('DATABASE_URL', None)
+    if database_url:
+        # Tell IPython to use PostgresContentsManager for all storage.
+        c.NotebookApp.contents_manager_class = pgcontents.PostgresContentsManager
+
+        # Set the url for the database used to store files.  See
+        # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#postgresql
+        # for more info on db url formatting.
+        c.PostgresContentsManager.db_url = database_url
+
+        # PGContents associates each running notebook server with a user, allowing
+        # multiple users to connect to the same database without trampling each other's
+        # notebooks. By default, we use the result of result of getpass.getuser(), but
+        # a username can be specified manually like so:
+        c.PostgresContentsManager.user_id = 'heroku'
+
+        # Set a maximum file size, if desired.
+        #c.PostgresContentsManager.max_file_size_bytes = 1000000 # 1MB File cap
+
+except Exception:
+    traceback.print_exc()
+    # if an exception occues, notebook normally would get started
+    # without password set. For security reasons, execution is stopped.
+    exit(-1)

--- a/jupyterconfig.py
+++ b/jupyterconfig.py
@@ -7,7 +7,7 @@ try:
     c = get_config()
 
     ### Password protection ###
-    passwd = os.getenv('JUPYTER_NOTEBOOK_PASSWORD')
+    passwd = os.environ['JUPYTER_NOTEBOOK_PASSWORD']
     c.NotebookApp.password = IPython.lib.passwd(passwd)
 
     ### PostresContentsManager ###


### PR DESCRIPTION
Errors / Exception in jupyterconfig lead to an unsecured notebook, where a terminal could be opened. This is a security risk. As a countermeasure any error inside configuration will block application startup.

Furthermore user must set a password before using jupyter notebook.
