### PR TITLE
Add 'nbextensions' support

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - nose
   - pip:
     - git+git://github.com/pl31/pgcontents.git
+    - git+git://github.com/ipython-contrib/jupyter_contrib_nbextensions.git

--- a/start_jupyter
+++ b/start_jupyter
@@ -2,7 +2,12 @@
 
 pgcontents init -l $DATABASE_URL --no-prompt
 
+mkdir -p /app/.jupyter
+cp jupyterconfig.py /app/.jupyter/jupyter_notebook_config.py
+
+jupyter contrib nbextension install --user
+jupyter nbextensions_configurator enable --user
+
 jupyter notebook \
 	--no-browser --no-mathjax --ip=* --port $PORT \
-	--config=jupyterconfig.py \
 	notebooks


### PR DESCRIPTION
Added suport for 'jupyter_contrib_nbextensions' duscussed here: #1

> I've tried to work it with the '--config' option , but did not go well .
> So I moved the config file to '/app/.jupyter/' and it went well .
