### PR TITLE
Fix minor typo for password check

### DIFF
--- a/.jupyter/jupyter_notebook_config.py
+++ b/.jupyter/jupyter_notebook_config.py
@@ -8,7 +8,7 @@ try:
     c = get_config()
 
     ### Password protection ###
-    if os.environ.get('JUPYTER_NOTBOOK_PASSWORD_DISABLED') != 'DangerZone!':
+    if os.environ.get('JUPYTER_NOTEBOOK_PASSWORD_DISABLED') != 'DangerZone!':
         passwd = os.environ['JUPYTER_NOTEBOOK_PASSWORD']
         c.NotebookApp.password = IPython.lib.passwd(passwd)
 


### PR DESCRIPTION
The JUPYTER_NOTEBOOK_PASSWORD_DISABLED env var check had missing `E` in the check.