### PR TITLE
Postgresql hobby > basic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
+#ECCN:Open Source

--- a/app.json
+++ b/app.json
@@ -24,6 +24,6 @@
     }
   },
   "addons": [
-    "heroku-postgresql:hobby-dev"
+    "heroku-postgresql:basic"
   ]
 }


### PR DESCRIPTION
Heroku postgres no longer has a hobby-dev plan, but has a basic plan instead. Refactoring to reflect this.

https://devcenter.heroku.com/changelog-items/2502